### PR TITLE
Let Requester.create_by_config parse files with ERB

### DIFF
--- a/lib/requester/requester.rb
+++ b/lib/requester/requester.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'httparty'
 require 'macaddr'
 require 'ostruct'
+require 'erb'
 require File.dirname(__FILE__) + '/../shared/ssh_tunnel'
 require File.expand_path(File.dirname(__FILE__) + '/../shared/testbot')
 
@@ -94,7 +95,9 @@ module Testbot::Requester
     end
 
     def self.create_by_config(path)
-      config = YAML.load_file(path)
+      file_contents = File.open(path).read
+      erb_processed = ERB.new(file_contents).result
+      config = YAML.load(erb_processed)
       Requester.new(config)
     end
 

--- a/test/requester/test_requester.rb
+++ b/test/requester/test_requester.rb
@@ -39,21 +39,35 @@ module Testbot::Requester
       flexmock(mock).should_receive(:size).and_return(0)
     end
 
+    def mock_file(local_path)
+      contents = File.open(File.join(File.dirname(__FILE__), local_path)).read
+      file = flexmock(File)
+      file.should_receive(:read).and_return(contents)
+      file
+    end
+
     context "self.create_by_config" do
 
       should 'create a requester from config' do
-        flexmock(YAML).should_receive(:load_file).once.with("testbot.yml").
-          and_return({ :server_host => 'hostname', :rsync_path => '/path',
-                     :rsync_ignores => ".git tmp", :available_runner_usage => '50%',
-                     :ssh_tunnel => false, :project => "appname", :server_user => "user" })
-        flexmock(Requester).should_receive(:new).once.with({ :server_host => 'hostname',
-                                                           :rsync_path => '/path', :rsync_ignores => '.git tmp',
-                                                           :available_runner_usage => '50%', :ssh_tunnel => false, :project => "appname",
-                                                           :server_user => "user" })
-        Requester.create_by_config("testbot.yml")
+        yml_file = mock_file("testbot.yml")
+        flexmock(File).should_receive(:open).with("testbot.yml").and_return(yml_file)
+        requester = Requester.create_by_config("testbot.yml")
+        assert_equal 'hostname', requester.config.server_host
+        assert_equal '/path', requester.config.rsync_path
+        assert_equal '.git tmp', requester.config.rsync_ignores
+        assert_equal 'appname', requester.config.project
+        assert_equal false, requester.config.ssh_tunnel
+        assert_equal 'user', requester.config.server_user
+        assert_equal '50%', requester.config.available_runner_usage
       end
 
-
+      should 'accept ERB-snippets in testbot.yml' do
+        yml_file = mock_file("testbot_with_erb.yml")
+        flexmock(File).should_receive(:open).with("testbot.yml").and_return(yml_file)
+        requester = Requester.create_by_config("testbot.yml")
+        assert_equal 'dynamic_host', requester.config.server_host
+        assert_equal '50%', requester.config.available_runner_usage
+      end
     end
 
     context "initialize" do

--- a/test/requester/testbot.yml
+++ b/test/requester/testbot.yml
@@ -1,0 +1,7 @@
+server_host: hostname
+rsync_path: /path
+rsync_ignores: .git tmp
+project: appname
+ssh_tunnel: false
+server_user: user
+available_runner_usage: 50%

--- a/test/requester/testbot_with_erb.yml
+++ b/test/requester/testbot_with_erb.yml
@@ -1,0 +1,2 @@
+server_host: <%= "dynamic_host" %>
+available_runner_usage: "<%= 50 %>%"


### PR DESCRIPTION
A file path is read and then parsed by ERB before it is loaded by YAML
- Added test to ensure testbot.yml is parsed by ERB
- Refactored previous test for consistency
