### PR TITLE
Updated sinatra requirement 

### DIFF
--- a/testbot.gemspec
+++ b/testbot.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.executables = [ "testbot" ]
   s.files       = Dir.glob("lib/**/*") + Dir.glob("test/**/*") + %w(Gemfile .gemtest Rakefile testbot.gemspec CHANGELOG README.markdown bin/testbot) +
                   (File.exists?("DEV_VERSION") ? [ "DEV_VERSION" ] : [])
-  s.add_dependency('sinatra', '=1.0.0') # To be able to use rack 1.0.1 which is compatible with rails 2.
+  s.add_dependency('sinatra', '>=1.0.0')
   s.add_dependency('httparty', '>= 0.6.1')
   s.add_dependency('macaddr', '>= 1.0.0')
   s.add_dependency('net-ssh', '>= 2.0.23')


### PR DESCRIPTION
Sinatra was defined in the gemspec as =1.0.0. We've updated it to >=1.0.0.

We've created this new pull request to replace https://github.com/joakimk/testbot/pull/35 because we accidentally included an extra commit in the previous one.

Ian & Andrew
