### PR TITLE
#49: Add Iconv as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       acts_as_rails3_generator
       daemons (>= 1.0.10)
       httparty (>= 0.6.1)
+      iconv (= 1.0.3)
       json_pure (>= 1.4.6)
       net-ssh (>= 2.0.23)
       posix-spawn (>= 0.3.6)
@@ -27,7 +28,7 @@ GEM
       celluloid (>= 0.15.0)
       nio4r (>= 0.5.0)
     coderay (1.1.0)
-    daemons (1.1.9)
+    daemons (1.2.3)
     ffi (1.9.3)
     flexmock (1.3.3)
     formatador (0.2.4)
@@ -40,11 +41,12 @@ GEM
     guard-test (2.0.4)
       guard (~> 2.0)
       test-unit (~> 2.2)
-    httparty (0.13.3)
+    httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.6.9)
-    json (1.8.2)
+    iconv (1.0.3)
+    json (1.8.3)
     json_pure (1.8.2)
     listen (2.5.0)
       celluloid (>= 0.15.2)
@@ -58,7 +60,7 @@ GEM
     multi_xml (0.5.5)
     net-ssh (2.9.2)
     nio4r (1.0.0)
-    posix-spawn (0.3.9)
+    posix-spawn (0.3.11)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -100,3 +102,6 @@ DEPENDENCIES
   rvm
   shoulda
   testbot!
+
+BUNDLED WITH
+   1.10.6

--- a/testbot.gemspec
+++ b/testbot.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('daemons', '>= 1.0.10')
   s.add_dependency('acts_as_rails3_generator')
   s.add_dependency('posix-spawn', '>= 0.3.6')
+  s.add_dependency('iconv', '1.0.3')
 
   s.add_development_dependency("shoulda")
   s.add_development_dependency("rack-test")


### PR DESCRIPTION
I assume this is related to [ruby versioning](http://stackoverflow.com/questions/29201518/in-require-cannot-load-such-file-iconv-loaderror).

Adding Iconv to dependency allowed me to start the runner on ruby 2.2.
