### PR TITLE
Loosen sinatra version constraints

### DIFF
--- a/testbot.gemspec
+++ b/testbot.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files       = Dir.glob("lib/**/*") + Dir.glob("test/**/*") + %w(Gemfile .gemtest Rakefile testbot.gemspec CHANGELOG README.markdown bin/testbot) +
                   (File.exists?("DEV_VERSION") ? [ "DEV_VERSION" ] : [])
 
-  s.add_dependency('sinatra', '~> 1.0.0')
+  s.add_dependency('sinatra', '~> 1.0')
   s.add_dependency('httparty', '>= 0.6.1')
   s.add_dependency('net-ssh', '>= 2.0.23')
   s.add_dependency('json_pure', '>= 1.4.6')


### PR DESCRIPTION
Blocking a gem update.

This allows 1.x, the previous one only allowed 1.0.x.

Could you also release a new gem after merging?